### PR TITLE
#90 - api 서비스들의 시큐리티 설정 업데이트

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboard/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             return  http.
                     authorizeHttpRequests(auth -> auth
                             .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                            .mvcMatchers("/api/**").permitAll()
                             .mvcMatchers(
                                        HttpMethod.GET,
                                     "/",
@@ -52,6 +53,7 @@ public class SecurityConfig {
                                     .userService(oAuth2UserService)
                             )
                     )
+                    .csrf(csrf -> csrf.ignoringAntMatchers("/api/**"))
                     .build();
     }
 


### PR DESCRIPTION
외부 서비스인 어드민 프로젝트에서 원활하게 게시판 서비스의 api를 이용할 수 있도록 보안 설정을 수정.

* csrf 인증을 api 통신일 때만 비활성화
* api 요청은 인증 없이 가능